### PR TITLE
Fix bug involving repeated github issues

### DIFF
--- a/scripts/github-issue-link.js
+++ b/scripts/github-issue-link.js
@@ -37,7 +37,7 @@ module.exports = function(robot) {
       if (included.indexOf(matches[0]) === -1)
         included.push(matches[0])
       else
-        break
+        continue
 
       const issueNumber = matches[2]
 


### PR DESCRIPTION
If a comment were of the form:

```
colonyNetwork#200 colonyNetwork#200 colonyNetwork#201
```

Then the second issue (which is a repeat of the first) would cause chewie to break out of the loop over all the regex matches, skipping all subsequent matches, rather than just skipping over the repeated issue. Replacing `break` with `continue` moves on to the next match, as intended.