### PR TITLE
Add ability to deploy to QA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: Build Docker Image
-          command: docker build -t eu.gcr.io/${GOOGLE_PROJECT_ID}/chewie-${CIRCLE_SHA1} .
+          command: docker build -t eu.gcr.io/${GOOGLE_PROJECT_ID}/chewie:${CIRCLE_SHA1} .
       - run:
           name: Store Service Account
           command: echo $GCLOUD_SERVICE_KEY | base64 --decode > ${HOME}/gcloud-service-key.json
@@ -27,8 +27,8 @@ jobs:
       - run:
           name: Deploy to Google Cloud
           command: |
-            gcloud docker -- push eu.gcr.io/${GOOGLE_PROJECT_ID}/chewie-${CIRCLE_SHA1}
-            kubectl patch deployment gitbutler -p '{"spec":{"template":{"spec":{"containers":[{"name":"chewie","image":"eu.gcr.io/'${GOOGLE_PROJECT_ID}'/chewie-'${CIRCLE_SHA1}'"}]}}}}'
+            gcloud docker -- push eu.gcr.io/${GOOGLE_PROJECT_ID}/chewie:${CIRCLE_SHA1}
+            kubectl patch deployment gitbutler -p '{"spec":{"template":{"spec":{"containers":[{"name":"chewie","image":"eu.gcr.io/'${GOOGLE_PROJECT_ID}'/chewie:'${CIRCLE_SHA1}'"}]}}}}'
 
 workflows:
   version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM gcr.io/google_appengine/nodejs
 
 RUN /usr/local/bin/install_node '>=0.12.7'
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+RUN apt-get update && apt-get install -y google-cloud-sdk kubectl
 COPY . /app/
 
 RUN yarn || \

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@colony/colony-js-adapter-ethers": "^1.4.1",
     "@colony/colony-js-client": "^1.5.1",
     "@slack/client": "^4.3.1",
+    "await-exec": "^0.1.2",
     "chrono-node": "^1.3.5",
     "cron": "^1.3.0",
     "env-cmd": "^8.0.2",

--- a/scripts/deployments.js
+++ b/scripts/deployments.js
@@ -1,9 +1,23 @@
 // Description:
 //   Used to deploy specified builds to QA
 const exec = require('await-exec')
+const { isChannel, isPrivateSlackMessage } = require('./utils/channels');
+
+const getBrain = require('./utils/brain');
+
+const BRAIN_PREFIX = 'deployment';
+
+const {
+  addToMap,
+  getFromMap,
+  getMap,
+  removeFromMap,
+  removeMap,
+  setMap,
+  updateMap,
+} = getBrain(BRAIN_PREFIX);
 
 module.exports = async function(robot) {
-  const deployRegex = /!(qa|staging|production) deploy ([0-9a-fA-f]*)/
 
   // Activate credentials
   await exec(`echo ${process.env.GCLOUD_SERVICE_KEY} | base64 --decode > /gcloud-service-key.json`);
@@ -13,14 +27,162 @@ module.exports = async function(robot) {
   await exec(`gcloud config set compute/zone ${process.env.GCLOUD_CLOUDSDK_COMPUTE_ZONE}`);
   await exec(`gcloud --quiet container clusters get-credentials ${process.env.GCLOUD_CLUSTER_NAME}`);
 
-  // Get the devops topic ID. The topic will be used to determine what colour is staging / production when asked to deploy to either.
+  // Get the devops channel ID. The topic will be used to determine what colour is staging / production when asked to deploy to either.
   let channels = await robot.adapter.client.web.conversations.list();
   let devopsChannel = channels.channels.filter(channel => channel.name === "devops")[0];
   const devopsid = devopsChannel.id
 
+
+  async function transformUserToID(user) {
+    let users = await robot.adapter.client.web.users.list();
+    users = users.members;
+    users = users.filter(u => (u.profile.display_name===user || u.name === user || u.id===user));
+    if (users.length === 0){
+      return [false, "Couldn't find such a user"];
+    } else if (users.length > 1){
+      return [false, "More than one user matched - be more specific"];
+    } else {
+      return [true, users[0].id];
+    }
+  }
+
+  const canDeploy = (userid, where, brain) => {
+    const users = getMap(`${where}Deployers`, brain);
+    return !!users[userid];
+  }
+  const isAdmin = (user, brain) => {
+    const admins = getMap('admins', brain)
+    return !!admins[user.id]
+  }
+
+  // Returns true if no admins exist yet
+  const noAdmins = brain => {
+    const admins = getMap('admins', brain)
+    if (!Object.keys(admins).length) {
+      return true
+    }
+    return false
+  }
+
+  const getUserNameFromID = (userToFind, brain) => {
+    const user = brain.userForId(userToFind)
+    return user ? user.name : userToFind
+  }
+
+  const addUserWithRole = (userid, role, brain) => {
+    return addToMap(`${role}s`, userid, true, brain)
+  }
+
+  const removeUserWithRole = (userid, role, brain) => {
+    return removeFromMap(`${role}s`, userid, brain)
+  }
+
+  const getUserList = (map, brain) => {
+  const userids = getMap(map, brain)
+  return Object.keys(userids)
+    .map(userid => `• <@${userid}>`)
+    .join('\n')
+  }
+
+  robot.hear(/!deployment permissions/, async(res) => {
+    const { brain } = robot
+    const { user } = res.message
+
+    if (!isPrivateSlackMessage(res)) return
+    if (!noAdmins(brain) && !isAdmin(user, brain)) return
+
+
+    const msg = `QA deployers:\n${getUserList(
+      'qaDeployers',
+      brain
+    )}\nStaging deployers:\n${getUserList(
+      'stagingDeployers',
+      brain
+    )}\nProduction deployers:\n${getUserList(
+      'productionDeployers',
+      brain
+    )}\nAdmins:\n${getUserList('admins', brain)}`
+    res.send(msg);
+
+  });
+
+  robot.hear(/!deployment admin add (.+)/, async (res) => {
+    const { user } = res.message
+    const { brain } = robot
+    const who = res.match[1].toLowerCase();
+
+    if (!isPrivateSlackMessage(res)) return
+    if (!noAdmins(brain) && !isAdmin(user, brain)) return
+    const [userLookupSuccess, userIDToAdd] = await transformUserToID(who)
+    if (!userLookupSuccess){
+      return msg.send(userIDToAdd);
+    }
+    if (userIDToAdd && addUserWithRole(userIDToAdd, 'admin', brain)) {
+      return res.send(
+        `I added <@${userIDToAdd}> as a deployment admin.`
+      )
+    }
+    return res.send(
+      'Could not add user as a deployment admin. Maybe they do not exist or are already?'
+    )
+  })
+
+  robot.hear(/!deployment add (.+) (.+)/, async (res) => {
+    const { user } = res.message
+    const { brain } = robot
+    const where = res.match[1].toLowerCase();
+    const who = res.match[2]
+
+    if (!isPrivateSlackMessage(res)) return
+    if (!noAdmins(brain) && !isAdmin(user, brain)) return
+    const [userLookupSuccess, userIDToAdd] = await transformUserToID(who)
+    if (!userLookupSuccess){
+      return msg.send(userIDToAdd);
+    }
+    if (userIDToAdd && addUserWithRole(userIDToAdd, `${where}Deployer`, brain)) {
+      return res.send(
+        `I added <@${userIDToAdd}> as ${where} deployer.`
+      )
+    }
+    return res.send(
+      `Could not add <@${userIDToAdd}> as a deployer. Maybe they do not exist or are already?`
+    )
+  })
+
+
+  robot.hear(/!deployment remove (.+) (.+)/, async (res) => {
+    const { user } = res.message
+    const { brain } = robot
+    const where = res.match[1].toLowerCase();
+    if (where !== "qa" && where !== "staging" && where !== "production") { return }
+    const who = res.match[2];
+
+    if (!isPrivateSlackMessage(res)) return
+    if (!noAdmins(brain) && !isAdmin(user, brain)) return
+    const [userLookupSuccess, userToRemove] = await transformUserToID(res.match[2])
+    if (!userLookupSuccess){
+      return res.send(userToRemove);
+    }
+    if (userToRemove && removeUserWithRole(userToRemove, `${where}Deployer`, brain)) {
+      return res.send(
+        `I removed <@${userToRemove}> as ${where} deployer.`
+      )
+    }
+    return res.send(
+      `Could not remove <@${userToRemove}> as ${where} deployer. Maybe they do not have the role?`
+    )
+  })
+
+  const deployRegex = /!deploy (qa|staging|production) ([0-9a-fA-f]*)/
   robot.hear(deployRegex, async msg => {
+    const { brain } = robot;
+
     const matches = deployRegex.exec(msg.message.text);
     if (matches[1] === 'qa'){
+      // Check they have permission
+      if (!canDeploy(msg.message.user.id, 'qa', brain)) {
+        return msg.send("You do not have that permission, as far as I can see? Take it up with the admins...");
+      }
       await exec('kubectl patch deployment dapp-red -p \'{"spec":{"template":{"spec":{"containers":[{"name":"dapp","image":"eu.gcr.io/fluent-aileron-128715/dapp-goerli:' + matches[2] + '"}]}}}}\'')
     } else if (matches[1] === 'staging' || matches[1] === 'production') {
       // Get colours
@@ -30,10 +192,18 @@ module.exports = async function(robot) {
       let colour;
 
       if (matches[1] === 'staging'){
+        // check they have staging permission
+        if (!canDeploy(msg.message.user.id, 'staging', brain)) {
+          return msg.send("You do not have that permission, as far as I can see? Take it up with the admins...");
+        }
         const stagingColourRegex = /Currently staging: ([a-zA-Z]*)/
         const stagingColourMatches = stagingColourRegex.exec(devopsTopic);
         colour = stagingColourMatches[1].toLowerCase();
       } else {
+        // check they have production permission
+        if (!canDeploy(msg.message.user.id, 'production', brain)) {
+          return msg.send("You do not have that permission, as far as I can see? Take it up with the admins...");
+        }
         const productionColourRegex = /Currently production\/live: ([a-zA-Z]*)/
         const productionColourMatches = productionColourRegex.exec(devopsTopic);
         colour = productionColourMatches[1].toLowerCase();

--- a/scripts/deployments.js
+++ b/scripts/deployments.js
@@ -3,7 +3,7 @@
 const exec = require('await-exec')
 
 module.exports = async function(robot) {
-  const deployRegex = /!qa deploy ([0-9a-fA-f]*)/
+  const deployRegex = /!(qa|staging|production) deploy ([0-9a-fA-f]*)/
 
   // Activate credentials
   await exec(`echo ${process.env.GCLOUD_SERVICE_KEY} | base64 --decode > /gcloud-service-key.json`);
@@ -13,10 +13,33 @@ module.exports = async function(robot) {
   await exec(`gcloud config set compute/zone ${process.env.GCLOUD_CLOUDSDK_COMPUTE_ZONE}`);
   await exec(`gcloud --quiet container clusters get-credentials ${process.env.GCLOUD_CLUSTER_NAME}`);
 
+  // Get the devops topic ID. The topic will be used to determine what colour is staging / production when asked to deploy to either.
+  let channels = await robot.adapter.client.web.conversations.list();
+  let devopsChannel = channels.channels.filter(channel => channel.name === "devops")[0];
+  const devopsid = devopsChannel.id
+
   robot.hear(deployRegex, async msg => {
     const matches = deployRegex.exec(msg.message.text);
+    if (matches[1] === 'qa'){
+      await exec('kubectl patch deployment dapp-red -p \'{"spec":{"template":{"spec":{"containers":[{"name":"dapp","image":"eu.gcr.io/fluent-aileron-128715/dapp-goerli:' + matches[2] + '"}]}}}}\'')
+    } else if (matches[1] === 'staging' || matches[1] === 'production') {
+      // Get colours
+      const response = await robot.adapter.client.web.channels.info(devopsid);
+      devopsChannel = response.channel;
+      const devopsTopic = devopsChannel.topic.value;
+      let colour;
 
-    await exec('kubectl patch deployment dapp-red -p \'{"spec":{"template":{"spec":{"containers":[{"name":"dapp","image":"eu.gcr.io/fluent-aileron-128715/dapp-goerli:' + matches[1] + '"}]}}}}\'')
+      if (matches[1] === 'staging'){
+        const stagingColourRegex = /Currently staging: ([a-zA-Z]*)/
+        const stagingColourMatches = stagingColourRegex.exec(devopsTopic);
+        colour = stagingColourMatches[1].toLowerCase();
+      } else {
+        const productionColourRegex = /Currently production\/live: ([a-zA-Z]*)/
+        const productionColourMatches = productionColourRegex.exec(devopsTopic);
+        colour = productionColourMatches[1].toLowerCase();
+      }
+      await exec('kubectl patch deployment dapp-' + colour +' -p \'{"spec":{"template":{"spec":{"containers":[{"name":"dapp","image":"eu.gcr.io/fluent-aileron-128715/dapp-main:' + matches[2] + '"}]}}}}\'' )
+    }
     msg.send('Container patched. Could take up to two minutes to start responding.')
   })
 }

--- a/scripts/deployments.js
+++ b/scripts/deployments.js
@@ -1,0 +1,22 @@
+// Description:
+//   Used to deploy specified builds to QA
+const exec = require('await-exec')
+
+module.exports = async function(robot) {
+  const deployRegex = /!qa deploy ([0-9a-fA-f]*)/
+
+  // Activate credentials
+  await exec(`echo ${process.env.GCLOUD_SERVICE_KEY} | base64 --decode > /gcloud-service-key.json`);
+  await exec('gcloud auth activate-service-account --key-file /gcloud-service-key.json');
+  await exec(`gcloud config set project ${process.env.GCLOUD_PROJECT_NAME}`);
+  await exec(`gcloud --quiet config set container/cluster ${process.env.GCLOUD_CLUSTER_NAME}`)
+  await exec(`gcloud config set compute/zone ${process.env.GCLOUD_CLOUDSDK_COMPUTE_ZONE}`);
+  await exec(`gcloud --quiet container clusters get-credentials ${process.env.GCLOUD_CLUSTER_NAME}`);
+
+  robot.hear(deployRegex, async msg => {
+    const matches = deployRegex.exec(msg.message.text);
+
+    await exec('kubectl patch deployment dapp-red -p \'{"spec":{"template":{"spec":{"containers":[{"name":"dapp","image":"eu.gcr.io/fluent-aileron-128715/dapp-goerli:' + matches[1] + '"}]}}}}\'')
+    msg.send('Container patched. Could take up to two minutes to start responding.')
+  })
+}

--- a/scripts/utils/brain.js
+++ b/scripts/utils/brain.js
@@ -37,8 +37,12 @@ module.exports = brainPrefix => {
 
   const removeFromMap = (mapKey, key, brain) => {
     const map = getMap(mapKey, brain);
+    if (!map[key]) {
+      return false;
+    }
     delete map[key];
     setMap(mapKey, map, brain);
+    return true;
   };
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,6 +283,11 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
+await-exec@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/await-exec/-/await-exec-0.1.2.tgz#c4dc58b415f9daf34fc9d17549f40fbc4839fd6b"
+  integrity sha512-BQUiyBLScS0+YPnnCZZGjb78mZ8sQ8aKgxarDPNw05rpbaCS7VIQSLy2tgjZKct9Dn1xLbKMXOpA98OWei90zA==
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"


### PR DESCRIPTION
With this PR, chewie will respond once again to `!qa deploy <commithash>`. Under the assumption that build pushed an image successfully, chewie will move qa.colony.io over to that commit, targeting goerli.

I've also changed the image tagging for chewie's images to use the commit hash as the tag, rather than as part of the image name. This will make it easier to prune stale images, which I'm going to start automating somehow...