### PR TITLE
Add parallel request for new QA env

### DIFF
--- a/scripts/deployments.js
+++ b/scripts/deployments.js
@@ -221,6 +221,21 @@ module.exports = async function(robot) {
     if (msg.match[3]){
       formData['client_payload']["DEV"] = "true";
     }
+
+    const repo = msg.match[1] === "frontend" ? "colonyDapp" : "colonyServer"
+
+    await request({
+      method: 'POST',
+      uri: `https://api.github.com/repos/joinColony/${repo}/dispatches`,
+      keepAlive: false,
+      body: JSON.stringify(formData),
+      headers:{
+        "Accept": "application/vnd.github.everest-preview+json",
+        "Authorization": `token ${process.env.HUBOT_GITHUB_TOKEN}`,
+        "User-Agent": "JoinColony/chewie",
+      }
+    });
+
     await request({
       method: 'POST',
       uri: `https://api.github.com/repos/joinColony/colony-deployment-scripts/dispatches`,


### PR DESCRIPTION
Enabling parallel build and deploy to new QA environment to make sure environment and ci/cd process are working as expected.

Once everything has been tested the github request sent to the colony-scrips repo can be removed.